### PR TITLE
Add a module for recursive tests.

### DIFF
--- a/aeson-extra.cabal
+++ b/aeson-extra.cabal
@@ -80,12 +80,16 @@ test-suite aeson-extra-test
     , base
     , base-compat-batteries
     , containers
-    , quickcheck-instances   >=0.3     && <0.4
-    , tasty                  >=0.10    && <1.5
-    , tasty-hunit            >=0.9     && <0.11
-    , tasty-quickcheck       >=0.8     && <0.11
+    , quickcheck-instances   >=0.3  && <0.4
+    , recursion-schemes
+    , tasty                  >=0.10 && <1.5
+    , tasty-hunit            >=0.9  && <0.11
+    , tasty-quickcheck       >=0.8  && <0.11
     , unordered-containers
     , vector
 
-  other-modules:    Orphans
+  other-modules:
+    Orphans
+    Recurse
+
   default-language: Haskell2010

--- a/src/Data/Aeson/Extra/Recursive.hs
+++ b/src/Data/Aeson/Extra/Recursive.hs
@@ -18,7 +18,7 @@
 -- stripNulls :: Value -> Value
 -- stripNulls = 'cata' ('embed' . f)
 --  where
---    f (ObjectF a) = ObjectF $ HM.filter (== Null) a
+--    f (ObjectF a) = ObjectF $ HM.filter (/= Null) a
 --    f x = x
 -- @
 module Data.Aeson.Extra.Recursive (

--- a/test/Recurse.hs
+++ b/test/Recurse.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE KindSignatures    #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
+module Recurse (recurseTests) where
+
+import Prelude ()
+import Prelude.Compat
+
+import Data.Aeson
+import Data.Aeson.Extra
+import Data.Functor.Foldable (cata, embed)
+
+import Test.QuickCheck.Instances ()
+import Test.Tasty
+import Test.Tasty.HUnit
+import qualified Data.HashMap.Strict as HM
+
+empty :: Value
+empty = $(mkValue' "{}")
+
+recurseTests :: TestTree
+recurseTests = testGroup "Recurse examples"
+  [ testCase "strip nulls" $ stripNulls $(mkValue' "{\"value\": null}") @?= empty
+  ]
+
+stripNulls :: Value -> Value
+stripNulls = cata (embed . f) where
+  f (ObjectF a) = ObjectF $ HM.filter (/= Null) a
+  f x = x

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -21,6 +21,7 @@ import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck
 
 import Orphans ()
+import Recurse (recurseTests)
 
 main :: IO ()
 main = defaultMain $ testGroup "Tests"
@@ -31,6 +32,7 @@ main = defaultMain $ testGroup "Tests"
   , collapsedListTests
   , mergeTests
   , streamTests
+  , recurseTests
   ]
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
Adds the `stripNulls` example from `Data.Aeson.Extra.Recursive` as a unit test. Used `cabal-fmt-0.1.5.1` on the updated package.